### PR TITLE
Add collapsible comments toggle to list and single pages

### DIFF
--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -74,3 +74,23 @@ div.highlight:hover .copy-code,
 pre:hover .copy-code {
     display: block;
 }
+
+.comments-toggle-section {
+    margin-top: 40px;
+}
+
+.comments-toggle-btn {
+    font-size: 14px;
+    line-height: 36px;
+    color: var(--theme);
+    background: var(--primary);
+    border: none;
+    border-radius: calc(36px / 2);
+    padding: 0 18px;
+    cursor: pointer;
+    transition: opacity 0.2s;
+}
+
+.comments-toggle-btn:hover {
+    opacity: 0.8;
+}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -103,8 +103,6 @@
 
 {{- end }}{{/* end profileMode */}}
 
-{{- if (.Param "comments") }}
-{{- partial "comments.html" . }}
-{{- end }}
+{{- partial "comments-toggle.html" . }}
 
 {{- end }}{{- /* end main */ -}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -52,9 +52,7 @@
     {{- end }}
   </footer>
 
-  {{- if (.Param "comments") }}
-  {{- partial "comments.html" . }}
-  {{- end }}
+  {{- partial "comments-toggle.html" . }}
 </article>
 
 {{- end }}{{/* end main */}}

--- a/layouts/members/list.html
+++ b/layouts/members/list.html
@@ -81,8 +81,6 @@
 </ul>
 {{- end }}
 
-{{- if (.Param "comments") }}
-{{- partial "comments.html" . }}
-{{- end }}
+{{- partial "comments-toggle.html" . }}
 
 {{- end }}{{/* end main */}}

--- a/layouts/partials/comments-toggle.html
+++ b/layouts/partials/comments-toggle.html
@@ -1,0 +1,16 @@
+{{- if and (not .IsHome) (.Param "comments") }}
+<div class="comments-toggle-section">
+  <button class="comments-toggle-btn" onclick="toggleComments(this)">💬 显示评论</button>
+  <div class="comments-body" hidden>
+    {{- partial "comments.html" . }}
+  </div>
+</div>
+<script>
+function toggleComments(btn) {
+  var body = btn.nextElementSibling;
+  var hidden = body.hasAttribute('hidden');
+  body.toggleAttribute('hidden');
+  btn.textContent = hidden ? '🔼 隐藏评论' : '💬 显示评论';
+}
+</script>
+{{- end }}

--- a/layouts/photos/list.html
+++ b/layouts/photos/list.html
@@ -40,8 +40,6 @@
 </section>
 {{- end }}
 
-{{- if (.Param "comments") }}
-{{- partial "comments.html" . }}
-{{- end }}
+{{- partial "comments-toggle.html" . }}
 
 {{- end }}{{/* end main */}}

--- a/layouts/publications/list.html
+++ b/layouts/publications/list.html
@@ -57,8 +57,6 @@
 </div>
 {{- end }}
 
-{{- if (.Param "comments") }}
-{{- partial "comments.html" . }}
-{{- end }}
+{{- partial "comments-toggle.html" . }}
 
 {{- end }}{{/* end main */}}

--- a/layouts/source/list.html
+++ b/layouts/source/list.html
@@ -48,8 +48,6 @@
   {{- end }}
 </div>
 
-{{- if (.Param "comments") }}
-{{- partial "comments.html" . }}
-{{- end }}
+{{- partial "comments-toggle.html" . }}
 
 {{- end }}{{/* end main */}}


### PR DESCRIPTION
- Add comments-toggle.html partial with show/hide button
- Replace direct comments rendering with toggle in all list templates
- Apply toggle to single.html so about page gets the option
- Style toggle button to match site's pill button design
- Suppress comments on home page